### PR TITLE
Add output file writer and logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ poetry.lock
 .coverage
 *.idx
 *log.txt
+mwr_l12l2/logs/log*
 mwr_l12l2/data/tropoe/node*
 .idea/
 .~lock.*

--- a/mwr_l12l2/config/L2_format.yaml
+++ b/mwr_l12l2/config/L2_format.yaml
@@ -1,0 +1,175 @@
+# config file for defining the format of the output L2 NetCDF #
+###############################################################
+
+dimensions:
+  unlimited:
+    - time  # refers to variable name in data dictionary
+  fixed:
+    - altitude
+    - bnds
+
+variables:
+  time:  # variable name in Measurement.data Dataset
+    name: time  # variable name in output NetCDF
+    dim:
+      - time
+    type: f8
+    _FillValue: null
+    optional: False
+    attributes:
+      long_name: Time (UTC) of the measurement
+      standard_name: time
+      units: seconds since 1970-01-01 00:00:00
+      calendar: standard
+      bounds: time_bnds
+      comment: Time indication of samples is at the end of integration time
+
+  time_bnds:
+    name: time_bnds
+    dim:
+      - time
+      - bnds
+    type: f8
+    _FillValue: null
+    optional: False
+    attributes:
+      long_name: Time interval endpoints
+
+  altitude:
+    name: altitude
+    dim:
+      - altitude
+    type: f4
+    _FillValue: -999.
+    optional: False
+    attributes:
+      long_name: Altitude above mean sea level
+      standard_name: altitude
+      units: m
+
+  lat:
+    name: station_latitude
+    dim:
+      - time
+    type: f4
+    _FillValue: -999.
+    optional: False
+    attributes:
+      long_name: Latitude of measurement station
+      standard_name: latitude
+      units: degree_north
+
+  lon:
+    name: station_longitude
+    dim:
+      - time
+    type: f4
+    _FillValue: -999.
+    optional: False
+    attributes:
+      long_name: Longitude of measurement station
+      standard_name: longitude
+      units: degree_east
+
+  # TODO: add quality_flag and quality_flag_status, possibly also freq-dependent vars
+
+  temperature:
+    name: temperature
+    dim:
+      - time
+      - altitude
+    type: f4
+    _FillValue: -999.
+    optional: True  #n none of the retrieved fields can be mandatory as T/q-only MWR's exist
+    attributes:
+      long_name: Retrieved temperature profile
+      standard_name: air_temperature
+      units: K
+
+  water_vapor_vmr:
+    name: water_vapor_vmr
+    dim:
+      - time
+      - altitude
+    type: f4
+    _FillValue: -999.
+    optional: True
+    attributes:
+      long_name: Retrieved water vapour profile
+      units: g/kg
+      # TODO should probably transform this to ppm to comply with the format definition doc. Synchronise with this document
+      # TODO: check for standard name and adequate units: https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html
+
+  lwp:
+    name: lwp
+    dim:
+      - time
+    type: f4
+    _FillValue: -999.
+    optional: True
+    attributes:
+      long_name: Retrieved column-integrated liquid water path
+      units: mm
+
+  pwv:
+    name: iwv
+    dim:
+      - time
+    type: f4
+    _FillValue: -999.
+    optional: True
+    attributes:
+      long_name: Calculated column-integrated liquid water path
+      comment: calculated from retrieved profile in water_vapor_vmr
+      units: mm
+
+  mlCAPE:
+    name: cape
+    dim:
+      - time
+    type: f4
+    _FillValue: -9999.  # TODO: this matches tropoe output. think of transforming to -999. for consistency
+    optional: True
+    attributes:
+      long_name: Convective available potential energy
+      comment: calculated from retrieved profiles
+      units: 1
+
+  mlCIN:
+    name: cin
+    dim:
+      - time
+    type: f4
+    _FillValue: -9999.  # TODO: this matches tropoe output. think of transforming to -999. for consistency
+    optional: True
+    attributes:
+      long_name: Convective inhibition
+      comment: calculated from retrieved profiles
+      units: 1
+
+  mlLCL:
+    name: lcl
+    dim:
+      - time
+    type: f4
+    _FillValue: -9999.  # TODO: this matches tropoe output. think of transforming to -999. for consistency
+    optional: True
+    attributes:
+      long_name: Convective inhibition
+      comment: calculated from retrieved profiles
+      units: m
+
+  # TODO: add errors to quantities and decide whether to report as random error or systematic error
+
+# global attributes common to all instruments. Additional instrument-specific attrs in their config under nc_attributes.
+# If the same fields are present in the instrument-specific config, the general ones from below will be overwritten
+attributes:
+  Conventions: CF-1.8
+  references: E-PROFILE data format description document
+  license: Closed-Use Non-Commercial General Licence 1.0 (CUNCGL)
+  network_name: E-PROFILE
+  campaign_name: ''
+  comment: ''
+  source: Ground Based Remote Sensing
+  dependencies: None
+  # history is directly set in NetCDF writer

--- a/mwr_l12l2/config/L2_format.yaml
+++ b/mwr_l12l2/config/L2_format.yaml
@@ -6,7 +6,6 @@ dimensions:
     - time  # refers to variable name in data dictionary
   fixed:
     - altitude
-    - bnds
 
 variables:
   time:  # variable name in Measurement.data Dataset
@@ -23,17 +22,6 @@ variables:
       calendar: standard
       bounds: time_bnds
       comment: Time indication of samples is at the end of integration time
-
-  time_bnds:
-    name: time_bnds
-    dim:
-      - time
-      - bnds
-    type: f8
-    _FillValue: null
-    optional: False
-    attributes:
-      long_name: Time interval endpoints
 
   altitude:
     name: altitude

--- a/mwr_l12l2/config/log_config.yaml
+++ b/mwr_l12l2/config/log_config.yaml
@@ -1,0 +1,19 @@
+# config file for setting logs destination and level #
+#####################################################
+
+logger_name: 'mwr_raw2l1'
+
+
+# configure logging to console (stdout). Logging to stdout is enabled in any case
+# -------------------------------------------------------------------------------
+loglevel_stdout: INFO  # level specification acceptable for logging module (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+
+# configure logging to file (only takes effect if write_logfile is set True)
+# CARE: Each run generates a new file. Consider while specifying timestamp_format to avoid overwriting
+# ----------------------------------------------------------------------------------------------------
+write_logfile: True
+logfile_path: mwr_l12l2/logs/  # absolute or relative to project dir
+logfile_basename: log_  # full filename will be logfile_basename + timestamp + logfile_ext
+logfile_ext: .txt  # file extension for logs files
+logfile_timestamp_format: '%Y%m%d%H%M%S'  # valid format for datetime's strftime()
+loglevel_file: INFO  # level specification acceptable for logging module

--- a/mwr_l12l2/config/log_config.yaml
+++ b/mwr_l12l2/config/log_config.yaml
@@ -1,7 +1,7 @@
 # config file for setting logs destination and level #
 #####################################################
 
-logger_name: 'mwr_raw2l1'
+logger_name: 'mwr_l12l2'
 
 
 # configure logging to console (stdout). Logging to stdout is enabled in any case

--- a/mwr_l12l2/config/retrieval_config.yaml
+++ b/mwr_l12l2/config/retrieval_config.yaml
@@ -15,7 +15,11 @@ data:
   inst_config_dir: mwr_l12l2/config/
   inst_config_file_prefix: config_
 
-  # location and filenames of E-PROFILE data
+  # location and filenames of output data
+  output_dir: mwr_l12l2/data/output/  # directory for microwave radiometer input data
+  output_file_prefix: MWR_2C01_
+
+  # location and filenames of input E-PROFILE data
   mwr_dir: mwr_l12l2/data/mwr/  # directory for microwave radiometer input data
   mwr_file_prefix: MWR_1C01_
   alc_dir: mwr_l12l2/data/alc/  # directory for automatic lidar's or ceilometer's cloud base input data

--- a/mwr_l12l2/errors.py
+++ b/mwr_l12l2/errors.py
@@ -15,16 +15,20 @@ class MWRDataError(MWRError):
     """Raised if something with the input data goes wrong"""
 
 
+class MWRRetrievalError(MWRError):
+    """Raised if something with the TROPoe retrieval failed"""
+
+
+class MWROutputError(MWRError):
+    """Raised when something with the output file goes wrong"""
+
+
 class MWRConfigError(MWRError):
     """Raised if something with the configuration file is wrong"""
 
 
 class MWRTestError(MWRError):
     """Raised if something goes wrong during set up or clean up of testing"""
-
-
-class MWRRetrievalError(MWRError):
-    """Raised if something with the TROPoe retrieval failed"""
 
 
 ###############################
@@ -40,3 +44,9 @@ class MissingDataError(MWRDataError):
 ###############################
 class FilenameError(MWRFileError):
     """Raised if the filename does not correspond to the expected pattern"""
+
+
+##############################
+class OutputDimensionError(MWROutputError):
+    """Raised if requested output dimensions do not match data"""
+

--- a/mwr_l12l2/errors.py
+++ b/mwr_l12l2/errors.py
@@ -23,6 +23,10 @@ class MWRTestError(MWRError):
     """Raised if something goes wrong during set up or clean up of testing"""
 
 
+class MWRRetrievalError(MWRError):
+    """Raised if something with the TROPoe retrieval failed"""
+
+
 ###############################
 class MissingConfig(MWRConfigError):
     """Raised if a mandatory entry of the config file is missing"""

--- a/mwr_l12l2/log.py
+++ b/mwr_l12l2/log.py
@@ -1,0 +1,70 @@
+import datetime as dt
+import os
+from logging import DEBUG, FileHandler, Formatter, StreamHandler, getLogger
+from sys import stdout
+
+from mwr_l12l2.utils.config_utils import get_log_config
+from mwr_l12l2.utils.file_utils import abs_file_path
+
+
+# get logs config
+log_config_file = abs_file_path('mwr_l12l2/config/log_config.yaml')
+conf = get_log_config(log_config_file)
+
+
+# Colors for the logs console output (Options see color_log-package)
+LOG_COLORS = {
+    'DEBUG': 'cyan',
+    'INFO': 'green',
+    'WARNING': 'yellow',
+    'ERROR': 'red',
+    'CRITICAL': 'red,bg_white'}
+
+try:
+    import colorlog
+
+    formatter = colorlog.ColoredFormatter(
+        '%(log_color)s%(asctime)s [%(process)d] '
+        '%(levelname)-8s %(message)s',
+        datefmt=None,
+        reset=True,
+        log_colors=LOG_COLORS,
+        secondary_log_colors={},
+        style='%',
+    )
+    get_logger = colorlog.getLogger
+
+except Exception as e:  # noqa E841
+    #   print(e)
+    get_logger = getLogger
+    formatter = Formatter(
+        '%(asctime)s [%(process)d] '
+        '%(levelname)-8s %(message)s',
+        '%Y-%m-%d %H:%M:%S',
+    )
+
+
+# general settings
+logger = get_logger(conf['logger_name'])
+logger.setLevel(DEBUG)  # set to the lowest possible level, using handler-specific levels for output
+
+
+# logging to stdout
+console_handler = StreamHandler(stdout)
+console_formatter = formatter
+console_handler.setFormatter(console_formatter)
+console_handler.setLevel(conf['loglevel_stdout'])
+logger.addHandler(console_handler)
+
+
+# logging to file
+if conf['write_logfile']:
+    act_time_str = dt.datetime.now(tz=dt.timezone(dt.timedelta(0))).strftime(conf['logfile_timestamp_format'])
+    log_filename = conf['logfile_basename'] + format(act_time_str) + conf['logfile_ext']
+    log_file = str(abs_file_path(os.path.join(conf['logfile_path'], log_filename)))
+
+    file_handler = FileHandler(log_file)
+    file_handler_formatter = formatter
+    file_handler.setFormatter(file_handler_formatter)
+    file_handler.setLevel(conf['loglevel_file'])
+    logger.addHandler(file_handler)

--- a/mwr_l12l2/logs/README
+++ b/mwr_l12l2/logs/README
@@ -1,0 +1,1 @@
+Log files are saved here per default. Consider manual removal from time to time. They are ignored by git.

--- a/mwr_l12l2/retrieval/retrieval.py
+++ b/mwr_l12l2/retrieval/retrieval.py
@@ -9,7 +9,7 @@ import xarray as xr
 from mwr_l12l2.errors import MissingDataError, MWRConfigError, MWRInputError, MWRRetrievalError
 from mwr_l12l2.log import logger
 from mwr_l12l2.model.ecmwf.interpret_ecmwf import ModelInterpreter
-from mwr_l12l2.retrieval.tropoe_helpers import model_to_tropoe, run_tropoe
+from mwr_l12l2.retrieval.tropoe_helpers import model_to_tropoe, run_tropoe, transform_units, height_to_altitude
 from mwr_l12l2.utils.config_utils import get_retrieval_config, get_inst_config
 from mwr_l12l2.utils.data_utils import datetime64_to_str, get_from_nc_files, has_data, datetime64_to_hour
 from mwr_l12l2.utils.file_utils import abs_file_path, concat_filename, datetime64_from_filename, dict_to_file
@@ -382,6 +382,10 @@ class Retrieval(object):
             raise MWRRetrievalError("Found several files matching {}. Don't know which TROPoe output to use.".format(
                 outfiles_pattern))
         pass
+        data = transform_units(data)
+        data = height_to_altitude(data, self.mwr.station_altitude)
+        # TODO: check if writer can handle case of lat/lon needing to be expanded to time dimension
+        # TODO write output file with writer
 
 
 if __name__ == '__main__':

--- a/mwr_l12l2/retrieval/retrieval.py
+++ b/mwr_l12l2/retrieval/retrieval.py
@@ -4,8 +4,10 @@ import shutil
 
 import datetime as dt
 import numpy as np
+import xarray as xr
 
-from mwr_l12l2.errors import MissingDataError, MWRConfigError, MWRInputError
+from mwr_l12l2.errors import MissingDataError, MWRConfigError, MWRInputError, MWRRetrievalError
+from mwr_l12l2.log import logger
 from mwr_l12l2.model.ecmwf.interpret_ecmwf import ModelInterpreter
 from mwr_l12l2.retrieval.tropoe_helpers import model_to_tropoe, run_tropoe
 from mwr_l12l2.utils.config_utils import get_retrieval_config, get_inst_config
@@ -44,6 +46,7 @@ class Retrieval(object):
         self.wigos = None
         self.inst_id = None
         self.inst_conf = None
+        self.tropoe_output_basename = None  # basename for output file by TROPoe (in tropoe_dir_mountpoint)
 
         # set by list_obs():
         self.mwr_files = None
@@ -147,6 +150,8 @@ class Retrieval(object):
         inst_conf_file = '{}{}_{}.yaml'.format(self.conf['data']['inst_config_file_prefix'],
                                                self.wigos, self.inst_id)
         self.inst_conf = get_inst_config(os.path.join(self.conf['data']['inst_config_dir'], inst_conf_file))
+
+        self.tropoe_output_basename = self.conf['data']['result_basefilename_tropoe'] + '_' + self.wigos + self.inst_id
 
     def list_obs_files(self):
         """get file lists for the selected station
@@ -298,16 +303,16 @@ class Retrieval(object):
 
         # Check for met data in the mwr level 1, if exist setup VIP file accordingly to read mwr level 1 file for 
         # surface data and if not taking lowest model level as surface data (with altitude offset)
-        if (self.sfc_temp_obs_exists & self.sfc_rh_obs_exists & self.sfc_p_obs_exists):
-            print('Surface data measured by the MWR')
+        if self.sfc_temp_obs_exists & self.sfc_rh_obs_exists & self.sfc_p_obs_exists:
+            logger.info('Surface data measured by the MWR')
             ext_sfc_data_type = 4
             sfc_data_offset = 0
             sfc_rootname = "mwr"
         else: 
-            print('No surface data measured by the MWR, using the forecast data instead')
+            logger.info('No surface data measured by the MWR, using the forecast data instead')
             ext_sfc_data_type = 1
             sfc_data_offset = self.met_sfc_offset
-            sfc_rootname = "met" # this should be the default value but better specify
+            sfc_rootname = "met"  # this should be the default value but better specify
 
         # update and complete vip entries with info from conf and data availability
         vip_edits = dict(mwr_n_tb_fields=len(self.mwr.frequency[ch_zenith]),
@@ -319,7 +324,7 @@ class Retrieval(object):
                          ext_sfc_wv_type=ext_sfc_data_type,  # 4 for mwr file, 1 for model file
                          ext_sfc_temp_type=ext_sfc_data_type,  # 4 for mwr file, 1 for model file
                          ext_sfc_relative_height=sfc_data_offset,
-                         ext_sfc_rootname = sfc_rootname,
+                         ext_sfc_rootname=sfc_rootname,
                          # TODO check what happens with surface pressure
                          mwr_path=self.tropoe_dir_mountpoint,
                          mwr_rootname=self.conf['data']['mwr_basefilename_tropoe'],
@@ -330,7 +335,7 @@ class Retrieval(object):
                          cbh_path=self.tropoe_dir_mountpoint,  # if no ALC is available, TROPoe uses default cbh of 2 km
                          ext_sfc_path=self.tropoe_dir_mountpoint,
                          output_path=self.tropoe_dir_mountpoint,
-                         output_rootname=self.conf['data']['result_basefilename_tropoe']+'_'+self.wigos,
+                         output_rootname=self.tropoe_output_basename,
                          )
         
         # Add scan variables to the VIP file only if they exist
@@ -364,8 +369,18 @@ class Retrieval(object):
     def postprocess_tropoe(self):
         """post-process the outputs of TROPoe and write to NetCDF file matching the E-PROFILE format"""
         # TODO: set up a writer producing the E-PROFILE format. 90% of mwr_raw2l1.write_netcdf() and
-        #  mwr_raw2l1.config.L1_format.yaml will be re-usable by just modifying the .yaml to match TROPoe output vars to
+        #  mwr_raw2l1.config.L2_format.yaml will be re-usable by just modifying the .yaml to match TROPoe output vars to
         #  the output format varnames and attributes
+        outfiles_pattern = os.path.join(self.tropoe_dir, self.tropoe_output_basename + '*.nc')
+        outfiles = glob.glob(outfiles_pattern)
+        if len(outfiles) == 1:
+            data = xr.open_dataset(outfiles[0])
+        elif len(outfiles) == 0:
+            raise MWRRetrievalError('Found no file matching {}. Possibly the TROPoe did not run through.'.format(
+                outfiles_pattern))
+        elif len(outfiles) > 1:
+            raise MWRRetrievalError("Found several files matching {}. Don't know which TROPoe output to use.".format(
+                outfiles_pattern))
         pass
 
 

--- a/mwr_l12l2/retrieval/tropoe_helpers.py
+++ b/mwr_l12l2/retrieval/tropoe_helpers.py
@@ -163,14 +163,23 @@ def transform_units(data):
 
 
 def height_to_altitude(data, station_altitude):
-    """transform height above ground level to altitude above mean sea level"""
+    """transform height above ground level to altitude above mean sea level and add as dataarray and coordinate
 
-    height_var = 'height'
-    altitude_var = 'altitude'
-    stn_altitude_var = 'station_altitude'
+    Args:
+        data: `xarray.Dataset` in which to change height to altitude
+        station_altitude: single value or array defining station altitude (in an array the first entry is considered)
 
-    # TODO: add transformer and renamer to altitude plus new var station altitude
-    return data
+    Returns:
+        updated dataset with altitude variable added (height also kept) and coordinate swapped from height to altitude
+    """
+
+    try:
+        station_altitude = station_altitude[0]
+    except TypeError:
+        pass
+    data.update({'station_altitude': station_altitude})
+    data['altitude'] = data['height'] + data['station_altitude']
+    return data.swap_dims({'height': 'altitude'})
 
 
 if __name__ == '__main__':

--- a/mwr_l12l2/retrieval/tropoe_helpers.py
+++ b/mwr_l12l2/retrieval/tropoe_helpers.py
@@ -73,14 +73,14 @@ def model_to_tropoe(model, station_altitude):
                                          attrs={'units': '%'}),
                       }
     # TODO: important! and easy... instead of just taking lowest altitude interp/extrapolate to station_altitude
-    # instead. use log for pressure
+    #  instead. use log for pressure
     sfc_data_attrs = {
         'model': 'surface quantities and uncertainties extracted from ECMWF operational forecast',
         'gridpoint_lat': central_lat,
         'gridpoint_lon': central_lon,                       
     }
     # TODO: add more detail on which ECMWF forecast is used to output file directly in main retrieval routine
-    # (info cannot be found inside grib file). Might also want to add lat/lon area used.
+    #  (info cannot be found inside grib file). Might also want to add lat/lon area used.
 
     # construct datasets
     prof_data = xr.Dataset.from_dict(prof_data_specs)

--- a/mwr_l12l2/retrieval/tropoe_helpers.py
+++ b/mwr_l12l2/retrieval/tropoe_helpers.py
@@ -142,5 +142,28 @@ def run_tropoe(data_path, date, start_hour, end_hour, vip_file, apriori_file,
     run(cmd)
 
 
+def transform_units(data):
+    """Transform all units of TROPoe output file to match units in E-PROFILE output files"""
+    nc_unit_attribute = 'units'
+
+    # unit_match contents. key: orig unit; value: (new unit, multiplier, adder)
+    unit_match = {'C': ('K', 1, 273.15),
+                  'km': ('m', 1e3, 0),
+                  'g/m2': ('mm', 1e-3, 0),  # for liquid water path
+                  'cm': ('mm', 10, 0),  # for integrated water vapour
+                  }
+
+    for var in data.variables:
+        if hasattr(data[var], nc_unit_attribute) and data[var].attrs[nc_unit_attribute] in unit_match:
+            transformer = unit_match[data[var].attrs[nc_unit_attribute]]
+            data[var] = data[var]*transformer[1] + transformer[2]
+            data[var].attrs[nc_unit_attribute] = transformer[0]
+
+    return data
+
+
 if __name__ == '__main__':
-    run_tropoe('mwr_l12l2/data', 0, 'dummy/vip.txt', 'dummy/Xa_Sa.Lindenberg.55level.08.cdf')
+    # run_tropoe('mwr_l12l2/data', 0, 'dummy/vip.txt', 'dummy/Xa_Sa.Lindenberg.55level.08.cdf')
+    x = xr.open_dataset('~/Desktop/tropoe_out_0-20000-0-10393A.20230425.131005.nc')
+    out = transform_units(x)
+    pass

--- a/mwr_l12l2/retrieval/tropoe_helpers.py
+++ b/mwr_l12l2/retrieval/tropoe_helpers.py
@@ -144,7 +144,6 @@ def run_tropoe(data_path, date, start_hour, end_hour, vip_file, apriori_file,
 
 def transform_units(data):
     """Transform all units of TROPoe output file to match units in E-PROFILE output files"""
-    nc_unit_attribute = 'units'
 
     # unit_match contents. key: orig unit; value: (new unit, multiplier, adder)
     unit_match = {'C': ('K', 1, 273.15),
@@ -152,13 +151,25 @@ def transform_units(data):
                   'g/m2': ('mm', 1e-3, 0),  # for liquid water path
                   'cm': ('mm', 10, 0),  # for integrated water vapour
                   }
+    unit_attribute = 'units'
 
     for var in data.variables:
-        if hasattr(data[var], nc_unit_attribute) and data[var].attrs[nc_unit_attribute] in unit_match:
-            transformer = unit_match[data[var].attrs[nc_unit_attribute]]
+        if hasattr(data[var], unit_attribute) and data[var].attrs[unit_attribute] in unit_match:
+            transformer = unit_match[data[var].attrs[unit_attribute]]
             data[var] = data[var]*transformer[1] + transformer[2]
-            data[var].attrs[nc_unit_attribute] = transformer[0]
+            data[var].attrs[unit_attribute] = transformer[0]
 
+    return data
+
+
+def height_to_altitude(data, station_altitude):
+    """transform height above ground level to altitude above mean sea level"""
+
+    height_var = 'height'
+    altitude_var = 'altitude'
+    stn_altitude_var = 'station_altitude'
+
+    # TODO: add transformer and renamer to altitude plus new var station altitude
     return data
 
 

--- a/mwr_l12l2/utils/config_utils.py
+++ b/mwr_l12l2/utils/config_utils.py
@@ -85,7 +85,8 @@ def get_retrieval_config(file):
                            'vip_filename_tropoe', 'result_basefilename_tropoe',
                            'mwr_basefilename_tropoe', 'alc_basefilename_tropoe',
                            'model_prof_basefilename_tropoe', 'model_sfc_basefilename_tropoe']
-    paths_data = ['inst_config_dir', 'mwr_dir', 'alc_dir', 'model_dir', 'tropoe_basedir']  # paths that shall be transformed to abs paths
+    # define paths which shall be transformed to abs paths:
+    paths_data = ['output_dir', 'inst_config_dir', 'mwr_dir', 'alc_dir', 'model_dir', 'tropoe_basedir']
     mandatory_keys_vip = []
     paths_vip = []  # paths that shall be transformed to abs paths
 

--- a/mwr_l12l2/utils/config_utils.py
+++ b/mwr_l12l2/utils/config_utils.py
@@ -156,6 +156,31 @@ def merge_mars_inst_config(mars_conf, inst_conf):
     return merged_conf
 
 
+def get_nc_format_config(file):
+    """get configuration for output NetCDF format and check for completeness of config file"""
+
+    mandatory_keys = ['dimensions', 'variables', 'attributes']
+    mandatory_variable_keys = ['name', 'dim', 'type', '_FillValue', 'optional', 'attributes']
+    mandatory_dimension_keys = ['unlimited', 'fixed']
+
+    conf = get_conf(file)
+
+    # verify conf dictionary structure
+    check_conf(conf, mandatory_keys,
+               'of config files defining output NetCDF format but is missing in {}'.format(file))
+    check_conf(conf['dimensions'], mandatory_dimension_keys,
+               "of 'dimensions' config files defining output NetCDF format but is missing in {}".format(file))
+    for varname, varval in conf['variables'].items():
+        check_conf(varval, mandatory_variable_keys,
+                   "of each variable in config files defining output NetCDF format but is missing for '{}' in {}"
+                   .format(varname, file))
+        if not isinstance(varval['dim'], list):
+            raise MWRConfigError("The value attributed to 'dim' in variable '{}' is not a list in {}"
+                                 .format(varname, file))
+
+    return conf
+
+
 def get_log_config(file):
     """get configuration for logger and check for completeness of config file"""
 

--- a/mwr_l12l2/utils/data_utils.py
+++ b/mwr_l12l2/utils/data_utils.py
@@ -81,6 +81,19 @@ def datetime64_to_hour(x):
     return np.sum(hms / hour_frac)
 
 
+def scalars_to_time(ds, variables, time_dim='time'):
+    """expand scalar variables onto time dimension to form an array of len(time) containing identical values
+
+    Args:
+        ds: :class:`xarray.Dataset` containing all requested scalar variables and the time dimension to transform to
+        variables: list of variables to expand onto the time dimension. These will be replaced in-place
+        time_dim (optional): name of the time dimension. Defaults to 'time'.
+    """
+    for var in variables:
+        ds.update({var: (time_dim, ds[var].values * np.ones(ds[time_dim].shape))})
+    return ds
+
+
 def lists_to_np(indict):
     """transform all values of a dict with type list to a :class:`numpy.ndarray`"""
     for key, val in indict.items():

--- a/mwr_l12l2/write_netcdf.py
+++ b/mwr_l12l2/write_netcdf.py
@@ -54,7 +54,7 @@ class Writer(object):
         self.global_attrs_from_conf(self.conf_nc, attr_key='attributes')
         if self.conf_inst is not None:
             self.global_attrs_from_conf(self.conf_inst, attr_key='nc_attributes')
-        self.add_title_attr()  # compose title
+        # self.add_title_attr()  # compose title #TODO: add an adequate title here
         self.add_history_attr()
         self.data.to_netcdf(self.filename, format=self.nc_format)  # write to output NetCDF file
         logger.info('Data written to ' + self.filename)
@@ -104,7 +104,7 @@ class Writer(object):
         except KeyError:
             logger.warning('No entry {} in conf file or dictionary'.format(attr_key))
 
-    def add_title_attr(self):
+    def add_title_attr(self):  # TODO: method is currently switched off. Adapt to something proper for L2 and switch on
         """add global attribute 'title' recombining info from other previously set global attributes"""
         if 'title' in self.data.attrs:
             return  # do not overwrite a title deliberately set by config

--- a/mwr_l12l2/write_netcdf.py
+++ b/mwr_l12l2/write_netcdf.py
@@ -85,7 +85,8 @@ class Writer(object):
                     self.data[var].attrs[att] = np.array(self.data[var].attrs[att], dtype=specs['type'])
 
         self.prepare_time()
-        self.append_qc_thresholds()
+        # TODO: removed append_qc_thresholds (present in mwr_raw2l1). Verify if method could be re-usable to propagate
+        #  tropoe attrs to output file
         self.remove_vars()
         self.rename_vars()  # must be last step
 
@@ -171,25 +172,6 @@ class Writer(object):
                 if att in self.data[var].attrs:
                     encs[att] = self.data[var].attrs.pop(att)
             self.data[var].encoding.update(encs)
-
-    def append_qc_thresholds(self):
-        """append quality control thresholds to comment attribute of quality_flag if not refused by 'conf_nc'"""
-
-        var = 'quality_flag'
-
-        # cases that need no action by this method
-        if var not in self.conf_nc['variables']:
-            return
-        if ('append_thresholds' in self.conf_nc['variables'][var] and not
-                self.conf_nc['variables'][var]['append_thresholds']):
-            return
-
-        # append thresholds to comment (or set new comment if absent)
-        if 'comment' in self.data[var].attrs:
-            new_comment = ' '.join([self.data[var].attrs['comment'], str(self.data.qc_thresholds.values)])
-        else:
-            new_comment = self.data.qc_thresholds.values
-        self.data[var].attrs.update({'comment': new_comment})
 
     def rename_vars(self):
         """set variable and dimension names to the ones set in conf_nc (CARE: must be last operation before save!)"""

--- a/mwr_l12l2/write_netcdf.py
+++ b/mwr_l12l2/write_netcdf.py
@@ -1,0 +1,208 @@
+import datetime as dt
+from copy import deepcopy
+
+import numpy as np
+from pkg_resources import get_distribution
+
+import mwr_l12l2
+from mwr_l12l2.errors import MissingConfig, OutputDimensionError
+from mwr_l12l2.log import logger
+from mwr_l12l2.utils.config_utils import get_inst_config, get_nc_format_config
+
+# value for _FillValue attribute of variables encoding field to have unset _FillValue in NetCDF
+ENC_NO_FILLVALUE = None  # tutorials from 2017 said False must be used, but with xarray 0.20.1 only None works
+
+
+class Writer(object):
+    """Class for writing data (Dataset) to NetCDF according to the format definition in conf_file
+
+    Args:
+        data_in: :class:`xarray.Dataset` or :class:`DataArray` containing data to write to file. Some support is also
+            provided if data_in is a dictionary, but this option is deprecated.
+        filename: name and path of output NetCDF file
+        conf_nc: configuration dict of yaml file defining the format and contents of the output NetCDF file
+        conf_inst: configuration dict of yaml file with instrument specifications (contains global attrs for NetCDF)
+        nc_format: NetCDF format type of the output file. Default is NETCDF4
+        copy_data (bool): In case of False, the dataset might experience in-place modifications which is suitable when
+            the dataset is not used in its original form after calling the write function, for True a copy is modified.
+            Defaults to False.
+    """
+
+    def __init__(self, data_in, filename, conf_nc, conf_inst, nc_format='NETCDF4', copy_data=False):
+        self.filename = filename
+        self.nc_format = nc_format
+        if copy_data:
+            self.data = deepcopy(data_in)
+        else:
+            self.data = data_in
+
+        # read in config file if config was not provided as dict
+        self.conf_nc = conf_nc
+        if not isinstance(self.conf_nc, dict):
+            self.conf_nc = get_nc_format_config(self.conf_nc)
+        self.conf_inst = conf_inst
+        if not isinstance(self.conf_inst, dict):
+            self.conf_inst = get_inst_config(self.conf_inst)
+        self.config_dims = self.conf_nc['dimensions']['unlimited'] + self.conf_nc['dimensions']['fixed']
+
+    def run(self):
+        """write Dataset to NetCDF according to the format definition in conf_file by using the :class:`xarray` module
+        """
+        logger.info('Starting to write to ' + self.filename)
+        self.prepare_datavars()
+        self.global_attrs_from_conf(self.conf_nc, attr_key='attributes')
+        self.global_attrs_from_conf(self.conf_inst, attr_key='nc_attributes')
+        self.add_title_attr()  # compose title
+        self.add_history_attr()
+        self.data.to_netcdf(self.filename, format=self.nc_format)  # write to output NetCDF file
+        logger.info('Data written to ' + self.filename)
+
+    def prepare_datavars(self):
+        """prepare data variables :class:`xarray.Dataset` for writing to file standard specified in 'conf_nc'"""
+
+        self.data.encoding.update(                                   # acts during to_netcdf()
+            unlimited_dims=self.conf_nc['dimensions']['unlimited'])  # default is fixed, i.e. only need to set unlimited
+        for var, specs in self.conf_nc['variables'].items():
+            # check availability and fill absent variables
+            if var not in self.data.keys():
+                if specs['optional']:
+                    shape_var = tuple(map(lambda x: len(self.data[x]), specs['dim']))
+                    self.data[var] = (specs['dim'], np.full(shape_var, np.nan))
+                else:
+                    raise KeyError('Variable {} is a mandatory input but was not found in input dictionary'.format(var))
+
+            # dimensions, fill value and encoding
+            self.check_dims(var, specs)
+            self.set_fillvalue(var, specs)
+            self.data[var].encoding.update(dtype=specs['type'])
+
+            # set attributes and make sure that encoding for flag_values and flag_masks corresponds to data type
+            self.data[var].attrs.update(specs['attributes'])
+            for att in ['flag_values', 'flag_masks']:
+                if att in self.data[var].attrs:
+                    self.data[var].attrs[att] = np.array(self.data[var].attrs[att], dtype=specs['type'])
+
+        self.prepare_time()
+        self.append_qc_thresholds()
+        self.remove_vars()
+        self.rename_vars()  # must be last step
+
+    def global_attrs_from_conf(self, conf, attr_key):
+        """add global attributes from configuration dictionary
+
+        Args:
+            conf: configuration dictionary with global attributes under the key given by attr_key
+            attr_key: string specifying the key under which attributes are stored in conf dict. Usually 'attributes' or
+                'nc_attributes'
+        """
+        for attname, attval in conf[attr_key].items():
+            self.data.attrs[attname] = attval
+
+    def add_title_attr(self):
+        """add global attribute 'title' recombining info from other previously set global attributes"""
+        if 'title' in self.data.attrs:
+            return  # do not overwrite a title deliberately set by config
+        # specify global attributes in order they will be used to set the title
+        att_seq = ['instrument_model', 'instrument_generation', 'site_location', 'institution']
+        for att in att_seq:
+            if att not in self.data.attrs:
+                raise MissingConfig("cannot set global attribute 'title' as attribute '{}' was not found in config"
+                                    .format(att))
+        self.data.attrs['title'] = '{} {} MWR at {} ({})'.format(*[self.data.attrs[att] for att in att_seq])
+
+    def add_history_attr(self):
+        """add global attribute 'history' with date and version of mwr_l12l2 code run"""
+        current_time_str = dt.datetime.now(tz=dt.timezone(dt.timedelta(0))).strftime('%Y%m%d')  # ensure UTC
+        proj_dir = mwr_l12l2.__file__.split('/')[-2]
+        try:
+            proj_dist = get_distribution(proj_dir)
+            hist_str = '{}: {} ({})'.format(current_time_str, proj_dist.project_name, proj_dist.version)
+        except Exception as err:  # noqa E722  # Don't want code to fail for just writing history
+            hist_str = '{}: mwr_l12l2'.format(current_time_str)
+            logger.warning('Received error {} while trying to set history global attribute. Therefore, will be using '
+                           'hardcoded project name without version number'.format(err))
+        self.data.attrs['history'] = hist_str
+
+    def check_dims(self, var, specs):
+        """check dims of var (retain order of config specs, but order of dims returned by xarray Dataset is arbitrary)
+
+        Args:
+            var (str): the name of the variable of whom the dimension shall be checked
+            specs: specifications for this variable from config. Must contain the key 'dim' with a list of dimensions.
+        """
+        if sorted(list(self.data[var].dims)) != sorted(specs['dim']):
+            # if last dim of specs is missing in data and scalar, add it to data (no need for subsequent check)
+            if sorted(list(self.data[var].dims)) == sorted(specs['dim'][:-1]) \
+                    and specs['dim'][-1] in self.data and len(self.data[specs['dim'][-1]]) == 1:
+                newdim = specs['dim'][-1]
+                tmp = self.data[var].expand_dims({newdim: 1}, axis=-1)
+                self.data[var] = tmp.assign_coords({newdim: self.data[newdim]})
+            else:
+                err_msg = "dimensions in data['{}'] (['{}']) do not match specs for output file (['{}'])".format(
+                    var, "', '".join(list(self.data[var].dims)), "', '".join(specs['dim']))
+                raise OutputDimensionError(err_msg)
+
+    def set_fillvalue(self, var, specs):
+        """set the fill value of var by taking care not to remove any fill value for dimensions for CF compliance
+
+        Args:
+            var (str): the name of the variable of whom the dimension shall be checked
+            specs: specifications for this variable from config. Must contain the key 'dim' with a list of dimensions.
+        """
+        if var in self.config_dims or specs['_FillValue'] is None:  # using None in fillna (else clause) destroys dtype
+            self.data[var].encoding.update(_FillValue=ENC_NO_FILLVALUE)
+        else:
+            self.data[var] = self.data[var].fillna(specs['_FillValue'])  # don't use with _FillValue=None, dtype problem
+            self.data[var].encoding.update(_FillValue=specs['_FillValue'])
+
+    def prepare_time(self):
+        """workaround for correctly setting units and calendar of time variable (use encoding instead of attrs)"""
+        time_vars = ['time']  # 'time' variable assumed to be always present
+        time_vars.extend([s for s in self.data.keys() if 'time_' in s or '_time' in s])  # get also *time_* and *_time*
+        time_vars.extend([var for var in self.data.keys() if 'calendar' in self.data[var].attrs])  # all with calendar
+        for var in time_vars:
+            encs = {}
+            for att in ['units', 'calendar']:
+                if att in self.data[var].attrs:
+                    encs[att] = self.data[var].attrs.pop(att)
+            self.data[var].encoding.update(encs)
+
+    def append_qc_thresholds(self):
+        """append quality control thresholds to comment attribute of quality_flag if not refused by 'conf_nc'"""
+
+        var = 'quality_flag'
+
+        # cases that need no action by this method
+        if var not in self.conf_nc['variables']:
+            return
+        if ('append_thresholds' in self.conf_nc['variables'][var] and not
+                self.conf_nc['variables'][var]['append_thresholds']):
+            return
+
+        # append thresholds to comment (or set new comment if absent)
+        if 'comment' in self.data[var].attrs:
+            new_comment = ' '.join([self.data[var].attrs['comment'], str(self.data.qc_thresholds.values)])
+        else:
+            new_comment = self.data.qc_thresholds.values
+        self.data[var].attrs.update({'comment': new_comment})
+
+    def rename_vars(self):
+        """set variable and dimension names to the ones set in conf_nc (CARE: must be last operation before save!)"""
+        varname_map = {var: specs['name'] for var, specs in self.conf_nc['variables'].items()}
+        self.data = self.data.rename(varname_map)
+        # take care of encoding set for unlimited dims
+        renamed_unlim_dim = [varname_map[dim] for dim in self.data.encoding['unlimited_dims']]
+        self.data.encoding['unlimited_dims'] = renamed_unlim_dim
+
+    def remove_vars(self):
+        """remove undesired variables and dimensions from data (all that are not in the conf_nc)"""
+        vars_to_drop = []
+        for var in self.data.variables:
+            if var not in self.conf_nc['variables']:
+                vars_to_drop.append(var)
+        self.data = self.data.drop_vars(vars_to_drop)
+        dims_to_drop = []
+        for var in self.data.dims:
+            if var not in self.config_dims:
+                dims_to_drop.append(var)
+        self.data = self.data.drop_dims(dims_to_drop)


### PR DESCRIPTION
- Add the output NetCDF file writer a skeleton of the config file with basic varibales and attributes (this includes a few unit and dimension transformations and matching from height to altitude to bring the TROPoe output to the required shape of the output file. Data format description at \\meteoswiss.ch\mch\MCH-OS\6\2\1\4\2\621.42-12 E-PROFILE Programme Management 2019-2023\business_case\MWR\DataFormatTaskForce\MWR_DataFormats\E-PROFILE_MWR_NetCDF_L2_data_format_mwr_v01.9.docx. For further devs, update this doc along with completing the output file config file (L2_format.yaml)
- Add a logger and use at a few instances. for further devs add more logging msgs
- quite some TODO's remain for @leric2 